### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 ## Overview
 A Model Context Protocol (MCP) server that seamlessly integrates with your [Readwise Reader](https://readwise.io/reader_api) library. This server enables MCP-compatible clients like Claude and VS Code to interact with your Reader library, providing capabilities for document listing, retrieval, and updates. It serves as a bridge between MCP clients and your personal knowledge repository in Readwise Reader.
 
+<a href="https://glama.ai/mcp/servers/@xinthink/reader-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xinthink/reader-mcp-server/badge" alt="Reader Server MCP server" />
+</a>
+
 ## Components
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [Reader MCP Server](https://glama.ai/mcp/servers/@xinthink/reader-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@xinthink/reader-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xinthink/reader-mcp-server/badge" alt="Reader Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.